### PR TITLE
Adds version field to goreleaser file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing


### PR DESCRIPTION
We need to add `version: 2` to the goreleaser file due to a change in the newest version of goreleaser. 


https://goreleaser.com/blog/goreleaser-v2/#upgrading