### PR TITLE
Changes changelog.skip to changelog.disable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,4 +58,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
As a part of the goreleaser changes, we need to change `changelog.skip` to `changelog.disable`.

More details can be found here:
https://goreleaser.com/deprecations/#changelogskip

`goreleaser check` output:
```
goreleaser check .goreleaser.yml
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```