### PR TITLE
Updates resource names to match provider name

### DIFF
--- a/examples/resources/aws_register/main.tf
+++ b/examples/resources/aws_register/main.tf
@@ -1,4 +1,4 @@
-resource "rad_security_aws_register" "this" {
+resource "rad-security_aws_register" "this" {
   rad_security_assumed_role_arn = "arn:aws:iam::<aws_account_number>:role/rad-security-connector"
   aws_account_id        = "aws_account_id"
 }

--- a/examples/resources/azure_register/main.tf
+++ b/examples/resources/azure_register/main.tf
@@ -1,4 +1,4 @@
-resource "rad_security_azure_register" "this" {
+resource "rad-security_azure_register" "this" {
   subscription_id = "123"
   tenant_id       = "456"
 }

--- a/internal/rad-security/provider.go
+++ b/internal/rad-security/provider.go
@@ -36,8 +36,8 @@ func New(version string) func() *schema.Provider {
 				},
 			},
 			ResourcesMap: map[string]*schema.Resource{
-				"rad_security_aws_register":   resourceAwsRegister(),
-				"rad_security_azure_register": resourceAzureRegister(),
+				"rad-security_aws_register":   resourceAwsRegister(),
+				"rad-security_azure_register": resourceAzureRegister(),
 			},
 			ConfigureContextFunc: configureProvider,
 		}


### PR DESCRIPTION
We need to change the prefix of the resource names to match the name of the provider. `rad_security_*` is not valid. It needs to start with `rad-security` instead. Not having the correct name resulted in the following error when trying to initialize. Adding the provider attribute allows us to get around it, but that is not a good solution.  

```
Initializing the backend...

Initializing provider plugins...
- Reusing previous version of rad-security/rad-security from the dependency lock file
- Finding latest version of hashicorp/rad...
- Reusing previous version of hashicorp/aws from the dependency lock file
- Using previously-installed rad-security/rad-security v1.0.2
- Using previously-installed hashicorp/aws v5.53.0
╷
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/rad: provider registry registry.terraform.io does not have a provider
│ named registry.terraform.io/hashicorp/rad
│
│ All modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which
│ modules are currently depending on hashicorp/rad, run the following command:
│     terraform providers
╵
```