### PR TITLE
Adds Cluster API Key Creation To Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # terraform-provider-rad-security
 This is the official Terraform Provider for Rad Security. Use this provider to interact with the Rad Security api. The provider can be found on the [Terraform Provider Registery](https://registry.terraform.io/providers/rad-security/rad-security/latest).
 
+
+## Cloud Connect
 To configure the provider, you will need a set of cloud api keys. The keys consist of an access and a secret key that can be generated from the Rad Security platform.
 
 To connect your AWS account to your Rad Security account, create a `rad_security_aws_register` resource where you run terraform for your AWS resources.
 
 An example of leveraging this resource can be found in our terraform module examples directory [here](https://github.com/rad-security/terraform-aws-rad-security-connect/blob/main/examples/main.tf)
+
+## Cluster API Key Provisioning
+The provider can be used to create new api keys to use with a new Kubernetes cluster. This is done with the `rad-security_cluster_api_key` resource.

--- a/internal/rad-security/provider.go
+++ b/internal/rad-security/provider.go
@@ -35,9 +35,11 @@ func New(version string) func() *schema.Provider {
 					Sensitive:   true,
 				},
 			},
+
 			ResourcesMap: map[string]*schema.Resource{
-				"rad-security_aws_register":   resourceAwsRegister(),
-				"rad-security_azure_register": resourceAzureRegister(),
+				"rad-security_aws_register":    resourceAwsRegister(),
+				"rad-security_azure_register":  resourceAzureRegister(),
+				"rad-security_cluster_api_key": resourceClusterAPIKey(),
 			},
 			ConfigureContextFunc: configureProvider,
 		}

--- a/internal/rad-security/resource_cluster_api_key.go
+++ b/internal/rad-security/resource_cluster_api_key.go
@@ -26,7 +26,7 @@ type ClusterAPIAccesskey struct {
 
 func resourceClusterAPIKey() *schema.Resource {
 	return &schema.Resource{
-		Description: "Register AWS account with Rad Security",
+		Description: "Create new cluster access keys to use",
 
 		CreateContext: resourceClusterAPIKeyCreate,
 		ReadContext:   resourceClusterAPIKeyRead,

--- a/internal/rad-security/resource_cluster_api_key.go
+++ b/internal/rad-security/resource_cluster_api_key.go
@@ -1,0 +1,162 @@
+package rad_security
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/rad-security/terraform-provider-rad-security/internal/request"
+)
+
+type CreateAccessKeyReq struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type ClusterAPIAccesskey struct {
+	ID        string     `json:"id"`
+	SecretKey string     `json:"secret_key"`
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
+	RevokedBy *string    `json:"revoked_by,omitempty"`
+}
+
+func resourceClusterAPIKey() *schema.Resource {
+	return &schema.Resource{
+		Description: "Register AWS account with Rad Security",
+
+		CreateContext: resourceClusterAPIKeyCreate,
+		ReadContext:   resourceClusterAPIKeyRead,
+		DeleteContext: resourceClusterAPIKeyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"access_key": {
+				Type:        schema.TypeString,
+				Description: "Rad Security Cluster Access Key",
+				Computed:    true,
+				Optional:    true,
+				Sensitive:   true,
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Description: "Rad Security Cluster Secret Key",
+				Computed:    true,
+				Optional:    true,
+				Sensitive:   true,
+			},
+		},
+	}
+}
+
+func resourceClusterAPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
+	var clusterAPIKeys ClusterAPIAccesskey
+
+	currentTime := time.Now()
+	formattedTime := currentTime.Format("15:04:05 02:01:2006")
+	formattedName := "Terraform-" + formattedTime
+
+	config := meta.(*Config)
+	apiUrlBase := config.RadSecurityApiUrl
+
+	targetURI := apiUrlBase + "/accounts/access_keys"
+	accessKey := config.AccessKeyId
+	secretKey := config.SecretKey
+
+	payload := &CreateAccessKeyReq{
+		Type: "plugin",
+		Name: formattedName,
+	}
+
+	statusCode, body, diags := request.AuthenticatedRequest(ctx, apiUrlBase, http.MethodPost, targetURI, accessKey, secretKey, payload)
+	if statusCode != http.StatusCreated {
+		return append(diags, diag.Errorf("Failed to register with Rad Security, received HTTP status: %d", statusCode)...)
+	}
+
+	err := json.Unmarshal(body, &clusterAPIKeys)
+	if err != nil {
+		return diag.Errorf("Error decoding JSON: %s", err)
+	}
+
+	err = d.Set("access_key", clusterAPIKeys.ID)
+	if err != nil {
+		return diag.Errorf("Error setting access_key: %s", err)
+	}
+
+	err = d.Set("secret_key", clusterAPIKeys.SecretKey)
+	if err != nil {
+		return diag.Errorf("Error setting secret_key: %s", err)
+	}
+
+	d.SetId(clusterAPIKeys.ID)
+
+	return diags
+}
+
+func resourceClusterAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var clusterAPIKeys ClusterAPIAccesskey
+
+	cloudAccessKey, ok := d.GetOk("access_key")
+	if !ok {
+		return diag.Errorf("Missing access_key")
+	}
+
+	config := meta.(*Config)
+	apiUrlBase := config.RadSecurityApiUrl
+	accessKey := config.AccessKeyId
+	secretKey := config.SecretKey
+
+	targetURI := apiUrlBase + "/accounts/access_keys/" + cloudAccessKey.(string)
+
+	payload := []byte{}
+
+	statusCode, body, diags := request.AuthenticatedRequest(ctx, apiUrlBase, http.MethodGet, targetURI, accessKey, secretKey, payload)
+	if statusCode != http.StatusOK {
+		if statusCode == http.StatusNotFound {
+			d.SetId("")
+			return diags
+		}
+		return append(diags, diag.Errorf("Failed to read cluster api keys. received HTTP status: %d", statusCode)...)
+	}
+
+	err := json.Unmarshal(body, &clusterAPIKeys)
+	if err != nil {
+		return diag.Errorf("Decoding JSON: %s", err)
+	}
+
+	if clusterAPIKeys.RevokedAt != nil {
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceClusterAPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	cloudAccessKey, ok := d.GetOk("access_key")
+	if !ok {
+		return diag.Errorf("Missing access_key")
+	}
+
+	config := meta.(*Config)
+	apiUrlBase := config.RadSecurityApiUrl
+	accessKey := config.AccessKeyId
+	secretKey := config.SecretKey
+
+	targetURI := apiUrlBase + "/accounts/access_keys/" + cloudAccessKey.(string) + "/revoke"
+
+	payload := []byte{}
+
+	statusCode, _, diags := request.AuthenticatedRequest(ctx, apiUrlBase, http.MethodPut, targetURI, accessKey, secretKey, payload)
+	if statusCode != http.StatusNoContent {
+		if statusCode == http.StatusNotFound {
+			d.SetId("")
+			return diags
+		}
+		return append(diags, diag.Errorf("Failed to delete cluster api keys. received HTTP status: %d", statusCode)...)
+	}
+
+	d.SetId("")
+	return nil
+}


### PR DESCRIPTION
Adds support for Cluster API Creation through a new resource called `rad-security_cluster_api_key`. 

It supports Creation, Reading, and Deleting. If the key is not found or if `revoked_at` is not empty, it will recreate it. Within Terraform,  `d.SetId("")` is removing the object from state. 