### PR TITLE
Change Azure Service Principal ID and Secret Fields To Include The Full Name

### DIFF
--- a/docs/guides/connecting_with_azure.md
+++ b/docs/guides/connecting_with_azure.md
@@ -22,20 +22,20 @@ resource "rad-security_azure_register" "example" {
 }
 ```
 
-No ID or Secret is needed, and Rad Security will use OIDC to syncronize resources from your Azure subscription.
+No Token ID or Secret is needed for the Service Principal, and Rad Security will use OIDC to synchronize resources from your Azure subscription.
 
 ## Connecting with ID and Secret
 
-This method uses a Service Principal ID and Secret for authentication with an existing Azure Service Principal. This is not the recommended method. OIDC is recommended as it is more secure and easier to manage.
+This method uses a Service Principal Token ID and Secret for authentication with an existing Azure Service Principal. This is not the recommended method. OIDC is recommended as it is more secure and easier to manage.
 
 In your Terraform configuration, use the rad-security_azure_register resource:
 
 ```hcl
 resource "rad-security_azure_register" "azure_connection" {
-  subscription_id           = "your-azure-subscription-id"
-  tenant_id                 = "your-azure-tenant-id"
-  service_principal_id      = "your-service-principal-id"
-  service_principal_secret  = "your-service-principal-secret"
+  subscription_id                = "your-azure-subscription-id"
+  tenant_id                      = "your-azure-tenant-id"
+  service_principal_token_id     = "your-service-principal-token-id"
+  service_principal_token_secret = "your-service-principal-token-secret"
 }
 ```
 
@@ -43,5 +43,5 @@ Replace the placeholder values with your actual Azure details:
 
 - `subscription_id`: Your Azure Subscription ID
 - `tenant_id`: Your Azure Tenant ID
-- `service_principal_id`: The ID of the Service Principal you created
-- `service_principal_secret`: The secret of the Service Principal
+- `service_principal_token_id`: The Token ID of the Service Principal you created
+- `service_principal_token_secret`: The Token Secret of the Service Principal

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,10 +31,18 @@ resource "rad-security_aws_register" "example" {
   aws_account_id                = "aws_account_id"
 }
 
-resource "rad-security_azure_register" "example" {
+resource "rad-security_azure_register" "example_with_oidc" {
   subscription_id = "123"
   tenant_id       = "456"
 }
+
+resource "rad-security_azure_register" "example_with_service_principal_id_and_secret" {
+  subscription_id                = "123"
+  tenant_id                      = "456"
+  service_principal_token_id     = "789"
+  service_principal_token_secret = "000"
+}
+
 resource "rad-security_cluster_api_key" "example" {}
 ```
 

--- a/docs/resources/azure_register.md
+++ b/docs/resources/azure_register.md
@@ -22,8 +22,8 @@ Register Azure Subscription and Tenant with Rad Security
 
 ### Optional
 
-- `service_principal_id` (String) Optional: Service principal ID to use when authenticating  with id and secret. OIDC based auth is the preferred option as it is more secure.
-- `service_principal_secret` (String) Optional: Service principal secret to use when authenticating with id and secret.  OIDC based auth is the preferred option as it is more secure.
+- `service_principal_token_id` (String) Optional: Service Principal Token ID to use when authenticating  with token id and secret. OIDC based auth is the preferred option as it is more secure.
+- `service_principal_token_secret` (String) Optional: Service Principal Token Secret to use when authenticating with token id and secret. OIDC based auth is the preferred option as it is more secure.
 
 ### Read-Only
 

--- a/examples/example_1.tf
+++ b/examples/example_1.tf
@@ -8,10 +8,18 @@ resource "rad-security_aws_register" "example" {
   aws_account_id                = "aws_account_id"
 }
 
-resource "rad-security_azure_register" "example" {
+resource "rad-security_azure_register" "example_with_oidc" {
   subscription_id = "123"
   tenant_id       = "456"
 }
+
+resource "rad-security_azure_register" "example_with_service_principal_id_and_secret" {
+  subscription_id                = "123"
+  tenant_id                      = "456"
+  service_principal_token_id     = "789"
+  service_principal_token_secret = "000"
+}
+
 resource "rad-security_cluster_api_key" "example" {}
 
 

--- a/examples/resources/azure_register/main.tf
+++ b/examples/resources/azure_register/main.tf
@@ -1,4 +1,11 @@
-resource "rad-security_azure_register" "this" {
+resource "rad-security_azure_register" "with_oidc" {
   subscription_id = "123"
   tenant_id       = "456"
+}
+
+resource "rad-security_azure_register" "with_service_principal_id_and_secret" {
+  subscription_id                = "123"
+  tenant_id                      = "456"
+  service_principal_token_id     = "789"
+  service_principal_token_secret = "000"
 }

--- a/internal/rad-security/resource_azure_register.go
+++ b/internal/rad-security/resource_azure_register.go
@@ -36,14 +36,14 @@ func resourceAzureRegister() *schema.Resource {
 				Description: "Target of the API path",
 				Computed:    true,
 			},
-			"service_principal_id": {
+			"service_principal_token_id": {
 				Type:        schema.TypeString,
-				Description: "Optional: Service principal ID to use when authenticating  with id and secret. OIDC based auth is the preferred option as it is more secure.",
+				Description: "Optional: Service Principal Token ID to use when authenticating  with token id and secret. OIDC based auth is the preferred option as it is more secure.",
 				Optional:    true,
 			},
-			"service_principal_secret": {
+			"service_principal_token_secret": {
 				Type:        schema.TypeString,
-				Description: "Optional: Service principal secret to use when authenticating with id and secret.  OIDC based auth is the preferred option as it is more secure.",
+				Description: "Optional: Service Principal Token Secret to use when authenticating with token id and secret. OIDC based auth is the preferred option as it is more secure.",
 				Optional:    true,
 			},
 

--- a/templates/guides/connecting_with_azure.md
+++ b/templates/guides/connecting_with_azure.md
@@ -22,20 +22,20 @@ resource "rad-security_azure_register" "example" {
 }
 ```
 
-No ID or Secret is needed, and Rad Security will use OIDC to syncronize resources from your Azure subscription.
+No Token ID or Secret is needed for the Service Principal, and Rad Security will use OIDC to synchronize resources from your Azure subscription.
 
 ## Connecting with ID and Secret
 
-This method uses a Service Principal ID and Secret for authentication with an existing Azure Service Principal. This is not the recommended method. OIDC is recommended as it is more secure and easier to manage.
+This method uses a Service Principal Token ID and Secret for authentication with an existing Azure Service Principal. This is not the recommended method. OIDC is recommended as it is more secure and easier to manage.
 
 In your Terraform configuration, use the rad-security_azure_register resource:
 
 ```hcl
 resource "rad-security_azure_register" "azure_connection" {
-  subscription_id           = "your-azure-subscription-id"
-  tenant_id                 = "your-azure-tenant-id"
-  service_principal_id      = "your-service-principal-id"
-  service_principal_secret  = "your-service-principal-secret"
+  subscription_id                = "your-azure-subscription-id"
+  tenant_id                      = "your-azure-tenant-id"
+  service_principal_token_id     = "your-service-principal-token-id"
+  service_principal_token_secret = "your-service-principal-token-secret"
 }
 ```
 
@@ -43,5 +43,5 @@ Replace the placeholder values with your actual Azure details:
 
 - `subscription_id`: Your Azure Subscription ID
 - `tenant_id`: Your Azure Tenant ID
-- `service_principal_id`: The ID of the Service Principal you created
-- `service_principal_secret`: The secret of the Service Principal
+- `service_principal_token_id`: The Token ID of the Service Principal you created
+- `service_principal_token_secret`: The Token Secret of the Service Principal


### PR DESCRIPTION
The fields `service_principal_id` and `service_principal_secret` in the `rad-security_azure_register` resource were not specific enough and caused confusion. This PR changes the name to `service_principal_token_id` and `service_principal_token_secret` to make it more clearer of their purpose. 