### PR TITLE
Adds support for registering Google Cloud Projects

### DIFF
--- a/internal/rad-security/provider.go
+++ b/internal/rad-security/provider.go
@@ -2,6 +2,7 @@ package rad_security
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -35,9 +36,10 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"rad-security_aws_register":    resourceAwsRegister(),
-			"rad-security_azure_register":  resourceAzureRegister(),
-			"rad-security_cluster_api_key": resourceClusterAPIKey(),
+			"rad-security_aws_register":          resourceAwsRegister(),
+			"rad-security_azure_register":        resourceAzureRegister(),
+			"rad-security_cluster_api_key":       resourceClusterAPIKey(),
+			"rad-security_google_cloud_register": resourceGoogleCloud(),
 		},
 		ConfigureContextFunc: configureProvider,
 	}
@@ -61,11 +63,15 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 }
 
 type RegistrationPayload struct {
-	Type                        string `json:"type"`
-	AWSAccountID                string `db:"aws_account_id" json:"aws_account_id"`
-	AWSRoleArn                  string `db:"aws_role_arn" json:"aws_role_arn"`
-	AzureSubscriptionID         string `db:"azure_subscription_id" json:"azure_subscription_id"`
-	AzureTenantID               string `db:"azure_tenant_id" json:"azure_tenant_id"`
-	AzureServicePrincipalID     string `json:"azure_service_principal_id"`
-	AzureServicePrincipalSecret string `json:"azure_service_principal_secret"`
+	Type                                        string  `json:"type"`
+	ID                                          string  `json:"id"`
+	AWSAccountID                                string  `json:"aws_account_id"`
+	AWSRoleArn                                  string  `json:"aws_role_arn"`
+	AzureSubscriptionID                         string  `json:"azure_subscription_id"`
+	AzureTenantID                               string  `json:"azure_tenant_id"`
+	AzureServicePrincipalID                     string  `json:"azure_service_principal_id"`
+	AzureServicePrincipalSecret                 string  `json:"azure_service_principal_secret"`
+	GoogleCloudProjectNumber                    *string `json:"google_cloud_project_number,omitempty"`
+	GoogleCloudWorkloadIdentityPoolProviderName *string `json:"google_cloud_workload_identity_pool_provider_name,omitempty"`
+	GoogleCloudServiceAccountEmail              *string `json:"google_cloud_service_account_email,omitempty"`
 }

--- a/internal/rad-security/provider.go
+++ b/internal/rad-security/provider.go
@@ -74,4 +74,5 @@ type RegistrationPayload struct {
 	GoogleCloudProjectNumber                    *string `json:"google_cloud_project_number,omitempty"`
 	GoogleCloudWorkloadIdentityPoolProviderName *string `json:"google_cloud_workload_identity_pool_provider_name,omitempty"`
 	GoogleCloudServiceAccountEmail              *string `json:"google_cloud_service_account_email,omitempty"`
+	RadAccountID                                string  `json:"account_id"`
 }

--- a/internal/rad-security/resource_google_cloud_register.go
+++ b/internal/rad-security/resource_google_cloud_register.go
@@ -1,0 +1,150 @@
+package rad_security
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/rad-security/terraform-provider-rad-security/internal/request"
+)
+
+func resourceGoogleCloud() *schema.Resource {
+	return &schema.Resource{
+		Description: "Register Google Cloud Project with Workload Federation",
+
+		CreateContext: resourceGoogleCloudWorkloadFederationCreate,
+		ReadContext:   resourceGoogleCloudWorkloadFederationRead,
+		UpdateContext: resourceGoogleCloudWorkloadFederationUpdate,
+		DeleteContext: resourceGoogleCloudWorkloadFederationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"google_cloud_service_account_email": {
+				Type:        schema.TypeString,
+				Description: "Google Cloud service account to impersonate",
+				Required:    true,
+			},
+			"google_cloud_pool_provider_name": {
+				Type:        schema.TypeString,
+				Description: "Google Cloud pool provider name",
+				Required:    true,
+			},
+			"google_cloud_project_number": {
+				Type:        schema.TypeString,
+				Description: "Google Cloud project number to sync resources with",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func resourceGoogleCloudWorkloadFederationCreate(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
+	var cloudAccount RegistrationPayload
+	config := meta.(*Config)
+	apiUrlBase := config.RadSecurityApiUrl
+
+	targetURI := apiUrlBase + "/cloud/register"
+	accessKey := config.AccessKeyId
+	secretKey := config.SecretKey
+
+	googleCloudServiceAccountEmail := d.Get("google_cloud_service_account_email").(string)
+	googleCloudPoolProviderName := d.Get("google_cloud_pool_provider_name").(string)
+	googleCloudProjectNumber := d.Get("google_cloud_project_number").(string)
+
+	payload := &RegistrationPayload{
+		Type:                     "google",
+		GoogleCloudProjectNumber: &googleCloudProjectNumber,
+		GoogleCloudWorkloadIdentityPoolProviderName: &googleCloudPoolProviderName,
+		GoogleCloudServiceAccountEmail:              &googleCloudServiceAccountEmail,
+	}
+
+	statusCode, body, diags := request.AuthenticatedRequest(ctx, apiUrlBase, http.MethodPost, targetURI, accessKey, secretKey, payload)
+	if statusCode != http.StatusOK {
+		return append(diags, diag.Errorf("Failed to register with Rad Security, received HTTP status: %d", statusCode)...)
+	}
+	err := json.Unmarshal(body, &cloudAccount)
+	if err != nil {
+		return diag.Errorf("Error decoding JSON: %s", err)
+	}
+
+	d.SetId(cloudAccount.ID)
+
+	return diags
+}
+
+func resourceGoogleCloudWorkloadFederationRead(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
+	var cloudAccount RegistrationPayload
+
+	cloudAccountID := d.Id()
+
+	config := meta.(*Config)
+	apiUrlBase := config.RadSecurityApiUrl
+
+	targetURI := apiUrlBase + "/cloud/" + cloudAccountID
+	accessKey := config.AccessKeyId
+	secretKey := config.SecretKey
+
+	statusCode, body, diags := request.AuthenticatedRequest(ctx, apiUrlBase, http.MethodGet, targetURI, accessKey, secretKey, nil)
+	if statusCode != http.StatusOK {
+		return append(diags, diag.Errorf("Failed to register with Rad Security, received HTTP status: %d", statusCode)...)
+	}
+
+	err := json.Unmarshal(body, &cloudAccount)
+	if err != nil {
+		return diag.Errorf("Error decoding JSON: %s", err)
+	}
+
+	return diags
+}
+
+func resourceGoogleCloudWorkloadFederationUpdate(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
+	var cloudAccount RegistrationPayload
+	config := meta.(*Config)
+	apiUrlBase := config.RadSecurityApiUrl
+
+	targetURI := apiUrlBase + "/cloud/register"
+	accessKey := config.AccessKeyId
+	secretKey := config.SecretKey
+
+	googleCloudServiceAccountEmail := d.Get("google_cloud_service_account_email").(string)
+	googleCloudPoolProviderName := d.Get("google_cloud_pool_provider_name").(string)
+	googleCloudProjectNumber := d.Get("google_cloud_project_number").(string)
+
+	payload := &RegistrationPayload{
+		Type:                     "google",
+		GoogleCloudProjectNumber: &googleCloudProjectNumber,
+		GoogleCloudWorkloadIdentityPoolProviderName: &googleCloudPoolProviderName,
+		GoogleCloudServiceAccountEmail:              &googleCloudServiceAccountEmail,
+	}
+
+	statusCode, body, diags := request.AuthenticatedRequest(ctx, apiUrlBase, http.MethodPut, targetURI, accessKey, secretKey, payload)
+	if statusCode != http.StatusOK {
+		return append(diags, diag.Errorf("Failed to register with Rad Security, received HTTP status: %d", statusCode)...)
+	}
+	err := json.Unmarshal(body, &cloudAccount)
+	if err != nil {
+		return diag.Errorf("Error decoding JSON: %s", err)
+	}
+
+	return diags
+}
+
+func resourceGoogleCloudWorkloadFederationDelete(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
+	cloudAccountID := d.Id()
+	config := meta.(*Config)
+	apiUrlBase := config.RadSecurityApiUrl
+
+	targetURI := apiUrlBase + "/cloud/" + cloudAccountID
+	accessKey := config.AccessKeyId
+	secretKey := config.SecretKey
+
+	statusCode, _, diags := request.AuthenticatedRequest(ctx, apiUrlBase, http.MethodGet, targetURI, accessKey, secretKey, nil)
+	if statusCode != http.StatusOK {
+		return append(diags, diag.Errorf("Failed to delete cloud account registration with Rad Security, received HTTP status: %d", statusCode)...)
+	}
+	d.SetId("")
+
+	return diags
+}

--- a/internal/rad-security/resource_google_cloud_register_test.go
+++ b/internal/rad-security/resource_google_cloud_register_test.go
@@ -71,7 +71,10 @@ func testAccGoogleCloudHttpMock(accessKeyID string, secretKey string, registrati
 			if req.AccessKeyID == accessKeyID && req.SecretKey == secretKey {
 				resp := auth.AuthResponse{Token: "mock_token"}
 				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(resp)
+				if err := json.NewEncoder(w).Encode(resp); err != nil {
+					http.Error(w, "failed to encode response", http.StatusInternalServerError)
+					return
+				}
 			} else {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 			}
@@ -80,10 +83,16 @@ func testAccGoogleCloudHttpMock(accessKeyID string, secretKey string, registrati
 			switch r.Method {
 			case http.MethodPost:
 				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(registrationResponse)
+				if err := json.NewEncoder(w).Encode(registrationResponse); err != nil {
+					http.Error(w, "failed to encode response", http.StatusInternalServerError)
+					return
+				}
 			case http.MethodPut:
 				w.WriteHeader(http.StatusNoContent)
-				json.NewEncoder(w).Encode(registrationResponse)
+				if err := json.NewEncoder(w).Encode(registrationResponse); err != nil {
+					http.Error(w, "failed to encode response", http.StatusInternalServerError)
+					return
+				}
 			default:
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			}
@@ -91,7 +100,10 @@ func testAccGoogleCloudHttpMock(accessKeyID string, secretKey string, registrati
 			w.Header().Set("Content-Type", "application/json")
 			switch r.Method {
 			case http.MethodGet:
-				json.NewEncoder(w).Encode(registrationResponse)
+				if err := json.NewEncoder(w).Encode(registrationResponse); err != nil {
+					http.Error(w, "failed to encode response", http.StatusInternalServerError)
+					return
+				}
 			case http.MethodDelete:
 				w.WriteHeader(http.StatusNoContent)
 			default:

--- a/internal/rad-security/resource_google_cloud_register_test.go
+++ b/internal/rad-security/resource_google_cloud_register_test.go
@@ -1,0 +1,120 @@
+package rad_security
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/rad-security/terraform-provider-rad-security/internal/auth"
+)
+
+func TestResourceGoogleCloudCreate(t *testing.T) {
+	radAccessKeyID := "test-access-key-id"
+	radSecretKey := "test-secret-key"
+
+	// Test data for Google Cloud registration
+	googleServiceAccount := "test-sa@project.iam.gserviceaccount.com"
+	googlePoolProvider := "test-pool-provider"
+	googleProjectNumber := "123456789"
+
+	resourceName := "rad-security_google_cloud_register.test"
+
+	response := &RegistrationPayload{
+		ID:                             "test-registration-id",
+		Type:                           "google",
+		GoogleCloudServiceAccountEmail: &googleServiceAccount,
+		GoogleCloudWorkloadIdentityPoolProviderName: &googlePoolProvider,
+		GoogleCloudProjectNumber:                    &googleProjectNumber,
+	}
+
+	mockServer := testAccGoogleCloudHttpMock(radAccessKeyID, radSecretKey, response)
+	defer mockServer.Close()
+
+	radAuth := auth.New(mockServer.URL)
+	providerFactories := setupRadSecurityProvider()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceGoogleCloudCreate(
+					radAuth.ApiURL,
+					radAccessKeyID,
+					radSecretKey,
+					googleServiceAccount,
+					googlePoolProvider,
+					googleProjectNumber,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_service_account_email", googleServiceAccount),
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_pool_provider_name", googlePoolProvider),
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_project_number", googleProjectNumber),
+				),
+			},
+		},
+	})
+}
+
+func testAccGoogleCloudHttpMock(accessKeyID string, secretKey string, registrationResponse *RegistrationPayload) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/authentication/authenticate" {
+			var req auth.AuthRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+
+			if req.AccessKeyID == accessKeyID && req.SecretKey == secretKey {
+				resp := auth.AuthResponse{Token: "mock_token"}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			} else {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			}
+		} else if r.URL.Path == "/cloud/register" {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.Method {
+			case http.MethodPost:
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(registrationResponse)
+			case http.MethodPut:
+				w.WriteHeader(http.StatusNoContent)
+				json.NewEncoder(w).Encode(registrationResponse)
+			default:
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			}
+		} else if r.URL.Path == "/cloud/"+registrationResponse.ID {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.Method {
+			case http.MethodGet:
+				json.NewEncoder(w).Encode(registrationResponse)
+			case http.MethodDelete:
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			}
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func testAccResourceGoogleCloudCreate(apiURL, radAccessKeyID, radSecretKey, serviceAccount, poolProvider, projectNumber string) string {
+	return fmt.Sprintf(`
+provider "rad-security" {
+  rad_security_api_url = "%s"
+  access_key_id        = "%s"
+  secret_key           = "%s"
+}
+
+resource "rad-security_google_cloud_register" "test" {
+  google_cloud_service_account_email = "%s"
+  google_cloud_pool_provider_name    = "%s"
+  google_cloud_project_number        = "%s"
+}
+`, apiURL, radAccessKeyID, radSecretKey, serviceAccount, poolProvider, projectNumber)
+}


### PR DESCRIPTION
Towards ENG-2128

Adds Google Cloud connect support using Google Cloud Workload Federation Identity.

This resource keeps track of the state by creating a resource id that uses the following format: `CLOUD_ACCOUNT_ID:RAD_ACCOUNT_ID`. The ids are returned from the original create request and are used to modify or delete the cloud connection. 